### PR TITLE
status -> upload_status

### DIFF
--- a/analyzere/base_resources.py
+++ b/analyzere/base_resources.py
@@ -215,7 +215,7 @@ class DataResource(Resource):
         return self._data_path + '/commit'
 
     @property
-    def status(self):
+    def upload_status(self):
         resp = request('get', self._status_path)
         return convert_to_analyzere_object(resp)
 
@@ -243,7 +243,7 @@ class DataResource(Resource):
 
         # Block until data has finished processing
         while True:
-            resp = self.status
+            resp = self.upload_status
             if (resp.status == 'Processing Successful' or
                     resp.status == 'Processing Failed'):
                 return resp

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, 'requirements', 'install.txt'),
 
 setup(
     name='analyzere',
-    version='0.3',
+    version='0.4',
     description='Python wrapper for the Analyze Re API.',
     long_description=readme,
     url='https://github.com/analyzere/analyzere-python',


### PR DESCRIPTION
For data-backed resources, use “upload_status” to avoid a potential issue with name collisions.