### PR TITLE
Use string headers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
+Daniel Arndt <dan@analyzere.com>
 Karl Leuschen <karl@analyzere.com>
 Peter Darrow <peter@analyzere.com>

--- a/analyzere/base_resources.py
+++ b/analyzere/base_resources.py
@@ -246,11 +246,13 @@ class DataResource(Resource):
         length = utils.file_length(file_obj)
 
         # Initiate upload session
-        request_raw('post', self._data_path, headers={'Entity-Length': length})
+        request_raw('post', self._data_path, headers={
+            'Entity-Length': str(length)
+        })
 
         # Upload chunks
         for chunk, offset in utils.read_in_chunks(file_obj, chunk_size):
-            headers = {'Offset': offset,
+            headers = {'Offset': str(offset),
                        'Content-Type': 'application/offset+octet-stream'}
             request_raw('patch', self._data_path, headers=headers, body=chunk)
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, 'requirements', 'install.txt'),
 
 setup(
     name='analyzere',
-    version='0.5.1',
+    version='0.5.2',
     description='Python wrapper for the Analyze Re API.',
     long_description=readme,
     url='https://github.com/analyzere/analyzere-python',

--- a/tests/test_base_resources.py
+++ b/tests/test_base_resources.py
@@ -368,14 +368,14 @@ class TestDataResource(SetBaseUrl):
 
         # Assert initiates session
         req = reqmock.request_history[0]
-        assert req.headers['Entity-Length'] == 4
+        assert req.headers['Entity-Length'] == '4'
         assert req.text is None
 
         # Assert uploads first chunk
         req = reqmock.request_history[1]
         assert req.headers['Content-Type'] == 'application/offset+octet-stream'
         assert req.headers['Content-Length'] == '4'
-        assert req.headers['Offset'] == 0
+        assert req.headers['Offset'] == '0'
         assert req.text == 'data'
 
         # Assert session committed


### PR DESCRIPTION
As of requests 2.11.0, requests strictly enforces that headers be  strings or buffers. We were using integers for some. See kennethreitz/requests#3386 for more info.