### PR TITLE
Ensure References are consistent with Proxy Object

### DIFF
--- a/analyzere/base_resources.py
+++ b/analyzere/base_resources.py
@@ -78,7 +78,6 @@ class Reference(Proxy):
                 return retval
             return newfunc
         else:
-            update_ref(Proxy)
             return attr
 
 

--- a/analyzere/base_resources.py
+++ b/analyzere/base_resources.py
@@ -35,12 +35,12 @@ class Reference(Proxy):
         def resolve():
             r = load_reference(
                 collection_name,
-                super(Reference, self).__getattribute__('_id')
+                Proxy.__getattribute__(self, '_id')
             )
             self._resolved = True
             return r
 
-        super(Reference, self).__init__(resolve)
+        Proxy.__init__(self, resolve)
 
     def __copy__(self):
         if self._resolved:
@@ -55,10 +55,11 @@ class Reference(Proxy):
     def __getattribute__(self, name):
         # Check for class methods and attributes before intercepting Proxied
         # methods and attributes.
-        if hasattr(Reference, name):
-            return super(Reference, self).__getattribute__(name)
 
         attr = Proxy.__getattribute__(self, name)
+        if hasattr(Reference, name):
+            return attr
+
         # Intercept all proxied attributes and methods and attempt to update
         # the Reference ._id and ._href attributes.
 
@@ -66,8 +67,8 @@ class Reference(Proxy):
             try:
                 id_ = item.id
                 href_ = urljoin(analyzere.base_url, item._get_path(id_))
-                super(Reference, self).__setattr__('_id', id_)
-                super(Reference, self).__setattr__('_href', href_)
+                self._id = id_
+                self._href = href_
             except AttributeError:
                 pass
 

--- a/tests/test_base_resources.py
+++ b/tests/test_base_resources.py
@@ -385,9 +385,14 @@ class TestResource(SetBaseUrl):
         assert r.id == 'abc123'
         assert r._id == 'abc123'
 
+        # check that _id and _href are not updated when simply calling an
+        # attribute.
         reqmock.put('https://api/foos/def123', status_code=200,
                     text='{"id": "def123", "server_generated": "bar"}')
         r.id = 'def123'
+        r.server_generated
+        assert r._id == 'abc123'
+
         r.save()
         assert r.id == r._id
         assert r._href == 'https://api/foos/def123'

--- a/tests/test_base_resources.py
+++ b/tests/test_base_resources.py
@@ -378,6 +378,20 @@ class TestResource(SetBaseUrl):
         assert f.foo == 'baz'
         assert not hasattr(f, 'throwaway')
 
+    def test_reference_save(self, reqmock):
+        reqmock.get('https://api/foos/abc123', status_code=200,
+                    text='{"id": "abc123", "server_generated": "foo"}')
+        r = Reference('https://api/foos/abc123')
+        assert r.id == 'abc123'
+        assert r._id == 'abc123'
+
+        reqmock.put('https://api/foos/def123', status_code=200,
+                    text='{"id": "def123", "server_generated": "bar"}')
+        r.id = 'def123'
+        r.save()
+        assert r.id == r._id
+        assert r._href == 'https://api/foos/def123'
+
 
 class Bar(DataResource):
     pass

--- a/tests/test_base_resources.py
+++ b/tests/test_base_resources.py
@@ -385,6 +385,11 @@ class TestResource(SetBaseUrl):
         assert r.id == 'abc123'
         assert r._id == 'abc123'
 
+        # Check to ensure Class attribute is not touched.
+        assert Reference._id is None
+        assert Reference._href is None
+        assert Reference._resolved is False
+
         # check that _id and _href are not updated when simply calling an
         # attribute.
         reqmock.put('https://api/foos/def123', status_code=200,
@@ -392,10 +397,50 @@ class TestResource(SetBaseUrl):
         r.id = 'def123'
         r.server_generated
         assert r._id == 'abc123'
+        assert Reference._id is None
+        assert Reference._href is None
+        assert Reference._resolved is False
 
         r.save()
         assert r.id == r._id
         assert r._href == 'https://api/foos/def123'
+        assert Reference._id is None
+        assert Reference._href is None
+        assert Reference._resolved is False
+
+    def test_reference_retrieve(self, reqmock):
+        reqmock.get('https://api/foos/abc123', status_code=200,
+                    text='{"id": "abc123", "server_generated": "foo"}')
+        r = Reference('https://api/foos/abc123')
+        assert r.id == 'abc123'
+        assert r._id == 'abc123'
+
+        # The retrieve method should not result in a change to the _id or _href
+        # attributes
+        reqmock.get('https://api/foos/def123', status_code=200,
+                    text='{"id": "def123", "server_generated": "bar"}')
+        r.retrieve('def123')
+        assert r._id == 'abc123'
+        assert r._href == 'https://api/foos/abc123'
+
+    def test_reference_reload(self, reqmock):
+        reqmock.get('https://api/foos/abc123', status_code=200,
+                    text='{"id": "abc123", "server_generated": "foo"}')
+        r = Reference('https://api/foos/abc123')
+        assert r.id == 'abc123'
+        assert r._id == 'abc123'
+
+        # The retrieve method should not result in a change to the _id or _href
+        # attributes
+        reqmock.get('https://api/foos/def123', status_code=200,
+                    text='{"id": "def123", "server_generated": "bar"}')
+        r.id = 'def123'
+        r.reload()
+        assert r._id == 'def123'
+        assert r._href == 'https://api/foos/def123'
+        assert Reference._id is None
+        assert Reference._href is None
+        assert Reference._resolved is False
 
 
 class Bar(DataResource):


### PR DESCRIPTION
This intercepts proxied methods and attributes on the inside the Reference and updates the `_id` and `_href`
attributes to ensure they are synchronized with wrapped object.