### PR TITLE
Expose the headers to the basic request

### DIFF
--- a/analyzere/requestor.py
+++ b/analyzere/requestor.py
@@ -33,13 +33,13 @@ def handle_api_error(resp, code):
         raise errors.ServerError(message, body, code, json_body)
 
 
-def request(method, path, params=None, headers={}, data=None,
+def request(method, path, params=None, headers=None, data=None,
             auto_retry=True):
     """
     method - HTTP method. e.g. get, put, post, etc.
     path - Path to resource. e.g. /loss_sets/1234
     params - Parameter to pass in the query string
-    headers - Additional HTTP headers
+    headers - Dictionary of additional HTTP headers
     data - Dictionary of parameters to pass in the request body
     """
     body = None

--- a/analyzere/requestor.py
+++ b/analyzere/requestor.py
@@ -33,7 +33,7 @@ def handle_api_error(resp, code):
         raise errors.ServerError(message, body, code, json_body)
 
 
-def request(method, path, params=None, headers={}, data=None, 
+def request(method, path, params=None, headers={}, data=None,
             auto_retry=True):
     """
     method - HTTP method. e.g. get, put, post, etc.
@@ -48,7 +48,7 @@ def request(method, path, params=None, headers={}, data=None,
 
     # append the default set of headers to any user provided headers
     if headers:
-        headers['accept']= 'application/json'
+        headers['accept'] = 'application/json'
         headers['content-type'] = 'application/json'
     else:
         headers = {

--- a/analyzere/requestor.py
+++ b/analyzere/requestor.py
@@ -33,21 +33,28 @@ def handle_api_error(resp, code):
         raise errors.ServerError(message, body, code, json_body)
 
 
-def request(method, path, params=None, data=None, auto_retry=True):
+def request(method, path, params=None, headers={}, data=None, 
+            auto_retry=True):
     """
     method - HTTP method. e.g. get, put, post, etc.
     path - Path to resource. e.g. /loss_sets/1234
     params - Parameter to pass in the query string
+    headers - Additional HTTP headers
     data - Dictionary of parameters to pass in the request body
     """
     body = None
     if data is not None:
         body = json.dumps(data, cls=utils.DateTimeEncoder)
 
-    headers = {
-        'accept': 'application/json',
-        'content-type': 'application/json',
-    }
+    # append the default set of headers to any user provided headers
+    if headers:
+        headers['accept']= 'application/json'
+        headers['content-type'] = 'application/json'
+    else:
+        headers = {
+            'accept': 'application/json',
+            'content-type': 'application/json',
+        }
     resp = request_raw(method, path, params=params, body=body, headers=headers,
                        auto_retry=auto_retry)
     content = resp.text


### PR DESCRIPTION
extend the ability to specify additional HTTP headers to the basic `request` to avoid having to use the more ugly `request_raw`.

With this change, the following "raw" request:
```python
resp = request_raw('GET',
                   'analysis_profiles',
                   params='ordering=-created&fields=event_catalogs,simulation,id,description',
                   headers={'References': 'expand'})
content = resp.text
content = json.loads(content, cls=utils.DateTimeDecoder)
profiles = convert_to_analyzere_object(content, analyzere.AnalysisProfile)
```
can be simplified to:
```python
profiles = request('GET',
                   'analysis_profiles',
                   params='ordering=-created&fields=event_catalogs,simulation,id,description',
                   headers={'References': 'expand'})
```