### PR TITLE
Handle type special case upon object init

### DIFF
--- a/analyzere/base_resources.py
+++ b/analyzere/base_resources.py
@@ -116,7 +116,7 @@ def to_dict(value):
 
 class AnalyzeReObject(object):
     def __init__(self, **kwargs):
-        type_value = kwargs.get('_type', None)
+        type_value = kwargs.pop('_type', None)
         if type_value:
             self.__dict__['type'] = type_value
         self.__dict__.update(kwargs)

--- a/analyzere/base_resources.py
+++ b/analyzere/base_resources.py
@@ -116,6 +116,9 @@ def to_dict(value):
 
 class AnalyzeReObject(object):
     def __init__(self, **kwargs):
+        type_value = kwargs.get('_type', None)
+        if type_value:
+            self.__dict__['type'] = type_value
         self.__dict__.update(kwargs)
 
     def __str__(self):

--- a/tests/test_base_resources.py
+++ b/tests/test_base_resources.py
@@ -110,7 +110,8 @@ class TestReferences(SetBaseUrl):
 
 class TestAnalyzeReObject:
     def test_initialize_from_kwargs(self):
-        a = AnalyzeReObject(foo='bar', baz='qux')
+        a = AnalyzeReObject(_type='sometype', foo='bar', baz='qux')
+        assert a.type == 'sometype'
         assert a.foo == 'bar'
         assert a.baz == 'qux'
 


### PR DESCRIPTION
I don't necessarily know that this is the way we want to handle this, but I thought i'd put it up for review.

The issue is this:
```python
layer = Layer() 
layer.type = 'NestedLayer' 
new_layer = Layer(**layer.to_dict()) 
print(new_layer.type) # AttributeError: 'Layer' object has no attribute 'type'
```

Some places we already handle this:

- We have a guard when using this function:
https://github.com/analyzere/analyzere-python/blob/976204774102a7f65aa9acec1e70b8d03742b9b4/analyzere/base_resources.py#L87-L89
- We have a guard when converting to a dict: https://github.com/analyzere/analyzere-python/blob/976204774102a7f65aa9acec1e70b8d03742b9b4/analyzere/base_resources.py#L155-L157
