### PR TITLE
Add user agent to requests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Oliver Baltzer <oliver@analyzere.com>
 Peter Darrow <peter@analyzere.com>
 Karl Leuschen <karl@analyzere.com>
 Duane Wilson <duane@analyzere.com>
+Ken Crowell <oeuftete@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,10 @@ Tagging
 2. Increment version number in ``setup.py`` according to
    `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_.
 
-3. Commit your change to ``setup.py`` and create a tag for it with the version
+3. Increment the version number in the ``user_agent`` variable in
+   ``analyzere/__init__.py``.
+
+4. Commit your change to ``setup.py`` and create a tag for it with the version
    number. e.g.::
 
     git tag 0.5.1

--- a/analyzere/__init__.py
+++ b/analyzere/__init__.py
@@ -5,6 +5,7 @@ upload_poll_interval = 0.1
 one_megabyte = 2**20
 upload_chunk_size = 16 * one_megabyte
 tls_verify = True
+user_agent = 'analyzere-python 0.5.5-dev'
 
 from analyzere.resources import (  # noqa
     AnalysisProfile,

--- a/analyzere/requestor.py
+++ b/analyzere/requestor.py
@@ -47,6 +47,7 @@ def request(method, path, params=None, data=None, auto_retry=True):
     headers = {
         'accept': 'application/json',
         'content-type': 'application/json',
+        'user-agent': analyzere.user_agent,
     }
     resp = request_raw(method, path, params=params, body=body, headers=headers,
                        auto_retry=auto_retry)

--- a/tests/test_requestor.py
+++ b/tests/test_requestor.py
@@ -63,6 +63,12 @@ class TestRequest:
     def teardown_method(self, _):
         analyzere.base_url = ''
 
+    def test_request_user_agent(self, reqmock):
+        reqmock.post('https://api/bar', status_code=201)
+        request('post', 'bar', data=None)
+        assert (reqmock.last_request.headers['User-Agent'] ==
+                analyzere.user_agent)
+
     def test_request_serialized(self, reqmock):
         reqmock.post('https://api/bar', status_code=201)
         request('post', 'bar', data={'foo': 'bar'})


### PR DESCRIPTION
Distinguish the library's user agent from direct usage of `requests`.