### PR TITLE
Add python 3.5 and 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
-env:
-  - TOXENV=py27
-  - TOXENV=py34
-install:
-  - pip install tox
-script:
-  - tox
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install: pip install tox-travis
+script: tox
 notifications:
   email: false
   hipchat:

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Oliver Baltzer <oliver@analyzere.com>
 Peter Darrow <peter@analyzere.com>
 Karl Leuschen <karl@analyzere.com>
 Duane Wilson <duane@analyzere.com>
+Ken Crowell <oeuftete@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ documentation.
 Testing
 -------
 
-We currently commit to being compatible with Python 2.7 and Python 3.4. In
+We currently commit to being compatible with Python 2.7. 3.4, 3.5, and 3.6. In
 order to run tests against against each environment we use
 `tox <http://tox.readthedocs.org/>`_ and `py.test <http://pytest.org/>`_. You'll
 need an interpreter installed for each of the versions of Python we test.

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     packages=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps = -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
Add python 3.5 and 3.6 support.  Only tested with the `tox` tests.