### PR TITLE
ARE-5466: Add tests for batch GET request

### DIFF
--- a/tests/test_base_resources.py
+++ b/tests/test_base_resources.py
@@ -344,7 +344,17 @@ class TestResource(SetBaseUrl):
 
         # With query params
         Foo.list(foo='bar')
-        assert reqmock.last_request.query == 'foo=bar'
+        assert len(reqmock.last_request.qs) == 1
+        assert reqmock.last_request.qs['foo'] == ['bar']
+
+        Foo.list(quux='baz,qux')
+        assert len(reqmock.last_request.qs) == 1
+        assert reqmock.last_request.qs['quux'] == ['baz,qux']
+
+        Foo.list(foo='bar', quux='baz,qux')
+        assert len(reqmock.last_request.qs) == 2
+        assert reqmock.last_request.qs['foo'] == ['bar']
+        assert reqmock.last_request.qs['quux'] == ['baz,qux']
 
     def test_save_new(self, reqmock):
         reqmock.post('https://api/foos/', status_code=200,


### PR DESCRIPTION
`reqmock.last_request.query` was replaced with `reqmock.last_request.qs` because the `qs` attribute contains some extra processing on the query string that's useful here (`query` returns the ASCII hexadecimal for commas `%2C`). 

https://github.com/jamielennox/requests-mock/blob/master/requests_mock/request.py#L99