### PR TITLE
Add profile to event catalog

### DIFF
--- a/analyzere/base_resources.py
+++ b/analyzere/base_resources.py
@@ -408,6 +408,13 @@ class MetricsResource(Resource):
         return convert_to_analyzere_object(data)
 
 
+class EventCatalogResource(DataResource):
+    def profile(self):
+        path = '%s/profile' % self._get_path(self.id)
+        resp = request('get', path)
+        return convert_to_analyzere_object(resp)
+
+
 class OptimizationResource(Resource):
     def result(self):
         path = '%s/result' % self._get_path(self.id)

--- a/analyzere/resources.py
+++ b/analyzere/resources.py
@@ -1,6 +1,7 @@
 from analyzere.base_resources import (
     DataResource,
     EmbeddedResource,
+    EventCatalogResource,
     MetricsResource,
     OptimizationResource,
     Resource,
@@ -20,7 +21,7 @@ class MonetaryUnit(EmbeddedResource):
 
 # Event catalogs
 
-class EventCatalog(DataResource):
+class EventCatalog(EventCatalogResource):
     pass
 
 


### PR DESCRIPTION
Adds a method on `EventCatalog`s to expose the catalog's profile which currently shows the attributes and their different values that were found when processing the event catalog.

```python
In [11]: event_catalog = analyzere.EventCatalog.retrieve('20b84996-...-c6a5b8db0622')

In [12]: event_catalog.profile()
Out[12]:
<EmbeddedResource at 0x7fce35fa0048> JSON: {
  "attributes": [
    {
      "_type": "str",
      "name": "Peril",
      "values": [
        "TH",
        "EQ",
        ....
```