### PR TITLE
ARE-6130: Python wrapper for currencies endpoint

### DIFF
--- a/analyzere/resources.py
+++ b/analyzere/resources.py
@@ -32,7 +32,7 @@ class EventCatalog(DataResource):
 
 class ExchangeRateTable(DataResource):
     def currencies(self):
-        path = '%s/currencies' % self._get_path(self.id)
+        path = '{}/currencies'.format(self._get_path(self.id))
         resp = request('get', path)
         # response will be an embedded object with currencies list
         # each element of the currencies list is again an embedded object with the structure like:

--- a/analyzere/resources.py
+++ b/analyzere/resources.py
@@ -31,7 +31,21 @@ class EventCatalog(DataResource):
 # Exchange rate tables
 
 class ExchangeRateTable(DataResource):
-    pass
+    def currencies(self):
+        path = '%s/currencies' % self._get_path(self.id)
+        resp = request('get', path)
+        # response will be an embedded object with currencies list
+        # each element of the currencies list is again an embedded object with the structure like:
+        #   {
+        #       "code": "CAD"
+        #   }
+        # I think we do not need to convert it to the more concise list, because we can extend the structure
+        # in the future like
+        #   {
+        #       "code": "CAD",
+        #       "rate": 1.32
+        #   }
+        return convert_to_analyzere_object(resp)
 
 
 class ExchangeRateSelectionRule(EmbeddedResource):

--- a/analyzere/resources.py
+++ b/analyzere/resources.py
@@ -39,12 +39,6 @@ class ExchangeRateTable(DataResource):
         #   {
         #       "code": "CAD"
         #   }
-        # I think we do not need to convert it to the more concise list, because we can extend the structure
-        # in the future like
-        #   {
-        #       "code": "CAD",
-        #       "rate": 1.32
-        #   }
         return convert_to_analyzere_object(resp)
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -83,15 +83,11 @@ class TestMarginal(SetBaseUrl):
 
     # ARE-6130 wrapper for the exchange rate table unique currencies function
     def test_unique_currencies(self, reqmock):
-
         # mock for the Exchange Rate table request
-        reqmock.get('https://api/exchange_rate_tables/abc_id', status_code=200, text='{"id":"abc_id"}')
+        reqmock.get('https://api/exchange_rate_tables/abc_id',
+                    status_code=200, text='{"id":"abc_id"}')
 
         fx_table = ExchangeRateTable.retrieve('abc_id')
-        dir(fx_table)
-        type(fx_table.id)
-        print(fx_table.id)
-        print("This is a print statement in test")
         # mock for the currencies method call
         reqmock.get('https://api/exchange_rate_tables/abc_id/currencies', status_code=200,
                     text='{'
@@ -102,14 +98,25 @@ class TestMarginal(SetBaseUrl):
                          ']'
                          '}')
         curr = fx_table.currencies()
-        type(curr)
-        # f = FooView(id='abc123')
-        # assert f.window_var((0.0, 1.0)).num == 1.0
+        assert hasattr(curr, 'currencies')
+        assert len(curr.currencies) == 2
+        currencies = set()
+        for c in curr.currencies:
+            currencies.add(c['code'])
+        assert currencies == {'EUR', 'CAD'}
 
-        # reqmock.get('https://api/foo_views/abc123/window_var/0.0_0.5,0.0_1.0',
-        #            status_code=200, text='[{"num": 1.0}, {"num": 2.0}]')
-        # wm = f.window_var([(0.0, 0.5), (0.0, 1.0)])
-        # assert len(wm) == 2
-        # assert wm[0].num == 1.0
-        # assert wm[1].num == 2.0
-        assert 1 == 1
+    # we still should have save the empty currencies list
+    def test_unique_currencies_empty(self, reqmock):
+        reqmock.get('https://api/exchange_rate_tables/abc_id',
+                    status_code=200, text='{"id":"abc_id"}')
+        fx_table = ExchangeRateTable.retrieve('abc_id')
+
+        reqmock.get('https://api/exchange_rate_tables/abc_id/currencies', status_code=200,
+                    text='{'
+                         '"currencies": '
+                         '[ '
+                         ']'
+                         '}')
+        curr = fx_table.currencies()
+        assert hasattr(curr, 'currencies')
+        assert len(curr.currencies) == 0

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -85,18 +85,12 @@ class TestMarginal(SetBaseUrl):
     def test_unique_currencies(self, reqmock):
         # mock for the Exchange Rate table request
         reqmock.get('https://api/exchange_rate_tables/abc_id',
-                    status_code=200, text='{"id":"abc_id"}')
+                    status_code=200, text='{"id": "abc_id"}')
 
         fx_table = ExchangeRateTable.retrieve('abc_id')
         # mock for the currencies method call
-        reqmock.get('https://api/exchange_rate_tables/abc_id/currencies', status_code=200,
-                    text='{'
-                         '"currencies": '
-                         '[ '
-                         '{"code": "CAD"}, '
-                         '{"code": "EUR"} '
-                         ']'
-                         '}')
+        reqmock.get('https://api/exchange_rate_tables/abc_id/currencies',
+                    status_code=200, text='{"currencies": [{"code": "CAD"}, {"code": "EUR"}]}')
         curr = fx_table.currencies()
         assert hasattr(curr, 'currencies')
         assert len(curr.currencies) == 2
@@ -111,12 +105,8 @@ class TestMarginal(SetBaseUrl):
                     status_code=200, text='{"id":"abc_id"}')
         fx_table = ExchangeRateTable.retrieve('abc_id')
 
-        reqmock.get('https://api/exchange_rate_tables/abc_id/currencies', status_code=200,
-                    text='{'
-                         '"currencies": '
-                         '[ '
-                         ']'
-                         '}')
+        reqmock.get('https://api/exchange_rate_tables/abc_id/currencies',
+                    status_code=200, text='{"currencies": []}')
         curr = fx_table.currencies()
         assert hasattr(curr, 'currencies')
         assert len(curr.currencies) == 0

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -2,7 +2,7 @@ import pytest
 
 import analyzere
 from analyzere import MonetaryUnit, LayerPolicy
-from analyzere.resources import PortfolioView, LayerView
+from analyzere.resources import PortfolioView, LayerView, ExchangeRateTable
 
 
 class SetBaseUrl(object):
@@ -80,3 +80,36 @@ class TestMarginal(SetBaseUrl):
         assert req_json['remove_layer_view_ids'][0]['ref_id'] == 'yyy'
 
         assert pv.id == 'a1'
+
+    # ARE-6130 wrapper for the exchange rate table unique currencies function
+    def test_unique_currencies(self, reqmock):
+
+        # mock for the Exchange Rate table request
+        reqmock.get('https://api/exchange_rate_tables/abc_id', status_code=200, text='{"id":"abc_id"}')
+
+        fx_table = ExchangeRateTable.retrieve('abc_id')
+        dir(fx_table)
+        type(fx_table.id)
+        print(fx_table.id)
+        print("This is a print statement in test")
+        # mock for the currencies method call
+        reqmock.get('https://api/exchange_rate_tables/abc_id/currencies', status_code=200,
+                    text='{'
+                         '"currencies": '
+                         '[ '
+                         '{"code": "CAD"}, '
+                         '{"code": "EUR"} '
+                         ']'
+                         '}')
+        curr = fx_table.currencies()
+        type(curr)
+        # f = FooView(id='abc123')
+        # assert f.window_var((0.0, 1.0)).num == 1.0
+
+        # reqmock.get('https://api/foo_views/abc123/window_var/0.0_0.5,0.0_1.0',
+        #            status_code=200, text='[{"num": 1.0}, {"num": 2.0}]')
+        # wm = f.window_var([(0.0, 0.5), (0.0, 1.0)])
+        # assert len(wm) == 2
+        # assert wm[0].num == 1.0
+        # assert wm[1].num == 2.0
+        assert 1 == 1


### PR DESCRIPTION
Python method to wrap the /exchange_rate_tables/id/currencies/ endpoint (ticket for endpoint was ARE-6109).