### PR TITLE
ARE-8107: Add global requests session instance for connection pooling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,10 +17,17 @@ Usage
 Please see http://docs.analyzere.net/?python for the most up-to-date
 documentation.
 
+Package Management
+---------------------
+
+The Analyze Re Python Client uses `Poetry <https://python-poetry.org/>`_ for
+package and dependency management. Poetry can be easily installed
+using either `pip` or `conda`.
+
 Testing
 -------
 
-`pytest` or `py.test`
+`poetry run pytest` (or) `poetry run py.test`
 
 Increment version
 -----------------
@@ -31,7 +38,9 @@ Testing Publication
 -------------------
 
 `poetry build`
-`poetry config.repositories.testpypi https://test.pypi.org`
+
+`poetry config repositories.testpypi https://test.pypi.org/legacy/`
+
 `poetry publish --repository testpypi`
 
 Publishing

--- a/README.rst
+++ b/README.rst
@@ -41,11 +41,12 @@ Testing Publication
 
 `poetry config repositories.testpypi https://test.pypi.org/legacy/`
 
-`poetry publish --repository testpypi`
+`poetry publish --repository testpypi --username __token__ --password <token_value>`
+
 
 Publishing
 ----------
 
 `poetry build`
 
-`poetry publish`
+`poetry publish --username __token__ --password <token_value>`

--- a/analyzere/__init__.py
+++ b/analyzere/__init__.py
@@ -5,7 +5,7 @@ upload_poll_interval = 0.1
 one_megabyte = 2**20
 upload_chunk_size = 16 * one_megabyte
 tls_verify = True
-user_agent = 'analyzere-python 0.6.0-dev'
+user_agent = 'analyzere-python 0.7.0-dev'
 
 from analyzere.resources import (  # noqa
     AnalysisProfile,

--- a/analyzere/requestor.py
+++ b/analyzere/requestor.py
@@ -8,6 +8,9 @@ import analyzere
 from analyzere import errors, utils
 
 
+session = requests.Session()
+
+
 def handle_api_error(resp, code):
     body = resp.text
     json_body = None
@@ -75,7 +78,7 @@ def request_raw(method, path, params=None, body=None, headers=None,
     if username and password:
         kwargs['auth'] = (username, password)
 
-    resp = requests.request(method, urljoin(analyzere.base_url, path),
+    resp = session.request(method, urljoin(analyzere.base_url, path),
                             **kwargs)
 
     # Handle HTTP 503 with the Retry-After header by automatically retrying
@@ -84,7 +87,7 @@ def request_raw(method, path, params=None, body=None, headers=None,
     while auto_retry and (resp.status_code == 503 and retry_after):
         time.sleep(float(retry_after))
         # Repeat original request after Retry-After time has elapsed.
-        resp = requests.request(method, urljoin(analyzere.base_url, path),
+        resp = session.request(method, urljoin(analyzere.base_url, path),
                                 **kwargs)
         retry_after = resp.headers.get('Retry-After')
 

--- a/analyzere/requestor.py
+++ b/analyzere/requestor.py
@@ -7,7 +7,6 @@ from six.moves.urllib.parse import urljoin
 import analyzere
 from analyzere import errors, utils
 
-
 session = requests.Session()
 
 
@@ -79,7 +78,7 @@ def request_raw(method, path, params=None, body=None, headers=None,
         kwargs['auth'] = (username, password)
 
     resp = session.request(method, urljoin(analyzere.base_url, path),
-                            **kwargs)
+                           **kwargs)
 
     # Handle HTTP 503 with the Retry-After header by automatically retrying
     # request after sleeping for the recommended amount of time
@@ -88,7 +87,7 @@ def request_raw(method, path, params=None, body=None, headers=None,
         time.sleep(float(retry_after))
         # Repeat original request after Retry-After time has elapsed.
         resp = session.request(method, urljoin(analyzere.base_url, path),
-                                **kwargs)
+                               **kwargs)
         retry_after = resp.headers.get('Retry-After')
 
     if handle_errors and (not 200 <= resp.status_code < 300):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "analyzere"
-version = "0.6.0"
+version = "0.7.0"
 description = ""
 authors = ["Developers <dev@analyzere.com>"]
 readme = "README.rst"
@@ -13,7 +13,6 @@ python = "^3.8.1"
 lazy-object-proxy = "^1.9.0"
 requests = "^2.31.0"
 six = "^1.16.0"
-
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^6.1.0"


### PR DESCRIPTION
The current implementation calls requests directly for each request made by the analyzere client, this opens a new connection for each request. The change here creates a session object in the global scope which is then used by request_raw to make the requests to the api. Using the session objects will make use of a connection pool to reuse connections see https://requests.readthedocs.io/en/latest/user/advanced/#session-objects for more.

The session changes has been published to https://test.pypi.org/project/analyzere/ and yet to be published to https://pypi.org/project/analyzere/. For testing, I installed the published package from Test PyPi locally and did the following:

```
import analyzere
import requests.adapters
from analyzere.requestor import session as analyzere_session
from getpass import getpass
from threading import Thread
from urllib3 import add_stderr_logger

add_stderr_logger()

analyzere.base_url = 'https://dev-uat-api.analyzere.net/'
analyzere.username = 'analyzere'
analyzere.password = getpass("Password: ")

print(f"User agent: {analyzere.user_agent}")

analyzere_session.mount("https://dev-uat-api.analyzere.net/", requests.adapters.HTTPAdapter(pool_maxsize=5))


def thread_get(url):
    analyzere_session.get(url)


t1 = Thread(target=thread_get, args=('https://dev-uat-api.analyzere.net/status',))
t2 = Thread(target=thread_get, args=('https://dev-uat-api.analyzere.net/analysis_profiles?ordering=-created&limit=1',))
t1.start()
t2.start()
t1.join()
t2.join()
t3 = Thread(target=thread_get, args=('https://dev-uat-api.analyzere.net/loss_filters?limit=5',))
t4 = Thread(target=thread_get, args=('https://dev-uat-api.analyzere.net/exchange_rate_tables/47791daf-e6c5-4739-a514-9ae5c0253332',))
t3.start()
t4.start()
t3.join()
t4.join()
```
And I got the following output:

> User agent: analyzere-python 0.7.0-dev
> 2024-02-29 10:01:41,388 DEBUG Starting new HTTPS connection (1): dev-uat-api.analyzere.net:443
> 2024-02-29 10:01:41,393 DEBUG Starting new HTTPS connection (2): dev-uat-api.analyzere.net:443
> 2024-02-29 10:01:41,641 DEBUG https://dev-uat-api.analyzere.net:443 "GET /analysis_profiles?ordering=-created&limit=1 HTTP/1.1" 401 59
> 2024-02-29 10:01:41,645 DEBUG https://dev-uat-api.analyzere.net:443 "GET /status HTTP/1.1" 401 59
> 2024-02-29 10:01:41,693 DEBUG https://dev-uat-api.analyzere.net:443 "GET /loss_filters?limit=5 HTTP/1.1" 401 59
> 2024-02-29 10:01:41,695 DEBUG https://dev-uat-api.analyzere.net:443 "GET /exchange_rate_tables/47791daf-e6c5-4739-a514-9ae5c0253332 HTTP/1.1" 401 59

As seen above, only two new connections were created and re-used when required instead of creating a new connection every time.
