### PR TITLE
Set connection pool maxsize and retries from new parameters

### DIFF
--- a/analyzere/__init__.py
+++ b/analyzere/__init__.py
@@ -20,6 +20,9 @@ one_megabyte = 2**20
 upload_chunk_size = 16 * one_megabyte
 tls_verify = True
 user_agent = 'analyzere-python 0.8-dev'
+connection_pool_maxsize = 10
+retry_strategy_total = 25
+retry_strategy_backoff_factor = 0.1
 
 from analyzere.resources import (  # noqa
     AnalysisProfile,

--- a/analyzere/__init__.py
+++ b/analyzere/__init__.py
@@ -21,7 +21,7 @@ upload_chunk_size = 16 * one_megabyte
 tls_verify = True
 user_agent = 'analyzere-python 0.8-dev'
 connection_pool_maxsize = 10
-retry_strategy_total = 25
+retry_strategy_total = 0
 retry_strategy_backoff_factor = 0.1
 
 from analyzere.resources import (  # noqa

--- a/analyzere/requestor.py
+++ b/analyzere/requestor.py
@@ -89,8 +89,9 @@ def ensure_session_exists(token_retrieval_kwargs):
         # Set connection pool and retry strategy
         retries = requests.adapters.Retry(total=analyzere.retry_strategy_total,
                                           backoff_factor=analyzere.retry_strategy_backoff_factor)
-        session.mount("https://",
-                      requests.adapters.HTTPAdapter(pool_maxsize=analyzere.connection_pool_maxsize, max_retries=retries))
+        session.mount(
+            "https://",
+            requests.adapters.HTTPAdapter(pool_maxsize=analyzere.connection_pool_maxsize, max_retries=retries))
 
 
 def request_raw(method, path, params=None, body=None, headers=None,

--- a/analyzere/requestor.py
+++ b/analyzere/requestor.py
@@ -2,6 +2,7 @@ import json
 import time
 
 import requests
+import requests.adapters
 from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
 from requests_oauthlib import OAuth2Session
 from six.moves.urllib.parse import urljoin
@@ -69,16 +70,27 @@ def request(method, path, params=None, data=None, auto_retry=True):
 def ensure_session_exists(token_retrieval_kwargs):
     global session
 
+    initializing_session = False
+
     if analyzere.oauth_client_id:
         # Ensure OAuth Session
         if not session or (not hasattr(session, 'client_id')) or session.client_id != analyzere.oauth_client_id:
+            initializing_session = True
             session = OAuth2Session(client=BackendApplicationClient(client_id=analyzere.oauth_client_id,
                                                                     scope=analyzere.oauth_scope))
             # Fetch first token
             session.fetch_token(analyzere.oauth_token_url, **token_retrieval_kwargs)
 
     elif not session:
+        initializing_session = True
         session = requests.Session()
+
+    if initializing_session:
+        # Set connection pool and retry strategy
+        retries = requests.adapters.Retry(total=analyzere.retry_strategy_total,
+                                          backoff_factor=analyzere.retry_strategy_backoff_factor)
+        session.mount("https://",
+                      requests.adapters.HTTPAdapter(pool_maxsize=analyzere.connection_pool_maxsize, max_retries=retries))
 
 
 def request_raw(method, path, params=None, body=None, headers=None,


### PR DESCRIPTION
`requests_oauthlib import OAuth2Session` is a subclass of `requests.Session` https://github.com/requests/requests-oauthlib/blob/master/requests_oauthlib/oauth2_session.py#L18.

Re-using the example from https://github.com/analyzere/analyzere-python/pull/58 (updated to use `analyzere.connection_pool_maxsize`):

```
import analyzere
import requests.adapters
from analyzere.requestor import session as analyzere_session
from getpass import getpass
from threading import Thread
from urllib3 import add_stderr_logger

add_stderr_logger()

analyzere.base_url = 'https://dev-uat-api.analyzere.net/'
analyzere.username = 'analyzere'
analyzere.password = getpass("Password: ")

print(f"User agent: {analyzere.user_agent}")

analyzere.connection_pool_maxsize=1


def get_catalogs():
    analyzere.EventCatalog.list()

def get_simulations():
    analyzere.Simulation.list()

def get_loss_filters():
    analyzere.LossFilter.list()

def get_fx_profiles():
    analyzere.ExchangeRateProfile.list()


t1 = Thread(target=get_catalogs)
t2 = Thread(target=get_simulations)
t1.start()
t2.start()
t1.join()
t2.join()
t3 = Thread(target=get_loss_filters)
t4 = Thread(target=get_fx_profiles)
t3.start()
t4.start()
t3.join()
t4.join()
```

With `analyzere.connection_pool_maxsize=1`, we see the discarding connection warning:
```
User agent: analyzere-python 0.8-dev
2024-12-30 10:25:02,843 DEBUG Starting new HTTPS connection (1): dev-uat-api.analyzere.net:443
2024-12-30 10:25:02,846 DEBUG Starting new HTTPS connection (2): dev-uat-api.analyzere.net:443
2024-12-30 10:25:03,373 DEBUG https://dev-uat-api.analyzere.net:443 "GET /event_catalogs/ HTTP/1.1" 200 7146
2024-12-30 10:25:03,429 DEBUG https://dev-uat-api.analyzere.net:443 "GET /simulations/ HTTP/1.1" 200 11148
2024-12-30 10:25:03,431 WARNING Connection pool is full, discarding connection: dev-uat-api.analyzere.net. Connection pool size: 1
2024-12-30 10:25:03,472 DEBUG Starting new HTTPS connection (3): dev-uat-api.analyzere.net:443
2024-12-30 10:25:04,008 DEBUG https://dev-uat-api.analyzere.net:443 "GET /exchange_rate_profiles/ HTTP/1.1" 200 7816
2024-12-30 10:25:04,411 DEBUG https://dev-uat-api.analyzere.net:443 "GET /loss_filters/ HTTP/1.1" 200 5573
2024-12-30 10:25:04,412 WARNING Connection pool is full, discarding connection: dev-uat-api.analyzere.net. Connection pool size: 1
```

And with `analyzere.connection_pool_maxsize=5`, we see only two connections started with no warning:
```
2024-12-30 10:24:10,572 DEBUG Starting new HTTPS connection (1): dev-uat-api.analyzere.net:443
2024-12-30 10:24:10,574 DEBUG Starting new HTTPS connection (2): dev-uat-api.analyzere.net:443
2024-12-30 10:24:11,098 DEBUG https://dev-uat-api.analyzere.net:443 "GET /simulations/ HTTP/1.1" 200 11148
2024-12-30 10:24:11,117 DEBUG https://dev-uat-api.analyzere.net:443 "GET /event_catalogs/ HTTP/1.1" 200 7146
2024-12-30 10:24:11,431 DEBUG https://dev-uat-api.analyzere.net:443 "GET /exchange_rate_profiles/ HTTP/1.1" 200 7816
2024-12-30 10:24:12,124 DEBUG https://dev-uat-api.analyzere.net:443 "GET /loss_filters/ HTTP/1.1" 200 5573
```